### PR TITLE
Matrix class

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+*.o
+*.a
+out.txt
+Miekki

--- a/Miekki.h
+++ b/Miekki.h
@@ -13,20 +13,22 @@
 #include <unordered_map>
 #include <unordered_set>
 #include "utils.h"
+#include "matrix.hpp"
 
 
 
 using namespace std;
 
+using score_t = uint32_t;
+using seqid_t = uint32_t;
+using matrix::idx_t;
 
 
-struct similarity_score{
-	uint32_t sequence_identifier;
-	uint32_t score;
-	//~ uint32_t active_minimizer;
+struct similarity_score {
+    seqid_t genome;
+    score_t matches;
+    double jaccard, intersection;
 };
-
-
 
 class Miekki{
 public:
@@ -58,7 +60,6 @@ public:
 	vector<uint64_t> genome_size;
 	omp_lock_t lock[10000];
 	ofstream* out;
-	vector<similarity_score> query_output;
 
 
 
@@ -97,10 +98,8 @@ public:
 	//CORE FUNCTIONS
 	void insert_sequence(const string& str, const string& title);
 	void insert_sequences(const vector<pair<string,string>>& Vstr);
-	vector<similarity_score> query_sequence(const string& str,uint32_t& lol);
-	vector<vector<similarity_score>> query_sequences( vector<pair<string,uint32_t>>& batch);
-	vector<vector<similarity_score>> query_sequences1(vector<pair<string,uint32_t>>& batch);
-	vector<vector<similarity_score>> query_sequences2(vector<pair<string,uint32_t>>& batch);
+    matrix::vector<score_t> query_sequence(const string& str,uint32_t& lol);
+    matrix::matrix<score_t> query_sequences(vector<pair<string,uint32_t>>& batch);
 	void query_file(const string& str);
 	void query_whole_file(const string& str);
 	void query_file_of_file(const string& str);
@@ -119,6 +118,7 @@ public:
 	minimizer mantis(uint64_t n);
 	pair<vector<minimizer>,vector<uint64_t>> minhash_sketch_partition(const string& reference,uint32_t& active_minimizer);
 	vector<minimizer>  minhash_sketch_partition_solid_kmers(const string& reference,uint32_t& active_minimizer);
+    template<typename T> void minhash_sketch_partition_solid_kmers(const string& reference,uint32_t& active_minimizer, T);
 	void ground_truth(const string& sequence,const string& file, double jax);
 	void ground_truth_batch(vector<pair<pair<string,string>,pair<double,double>>>& V,string file);
 	void insert_bloom(uint64_t);
@@ -129,6 +129,10 @@ public:
 	void update_kmer_RC(kmer& min, char nuc);
 	kmer rcb(kmer min);
 	void merge_indexes(Miekki* other_index);
+
+    void filter_results(matrix::refvec<score_t> results, size_t nresults, score_t min_score, double min_intersection, std::vector<similarity_score>& min_heap);
+    std::vector<matrix::vector<similarity_score>> filter_results(matrix::matrix<score_t> results, size_t nresults, score_t min_score, double min_intersection);
+    std::vector<similarity_score> filter_results(matrix::refvec<score_t> results, size_t nresults, score_t min_score, double min_intersection);
 
 };
 

--- a/common.hpp
+++ b/common.hpp
@@ -1,0 +1,81 @@
+#ifndef GATBL_COMMON_HPP
+#define GATBL_COMMON_HPP
+
+#include <cstdio>
+#include <cstdlib>
+#include <cstdarg>
+#include <exception>
+
+#define packed_layout __attribute__((__packed__))
+#define noinline_fun __attribute__((noinline))
+#define forceinline_fun inline __attribute__((always_inline))
+#define flatten_fun __attribute__((flatten))
+#define pure_fun __attribute__((const))
+#define hot_fun __attribute__((hot))
+#define cold_fun __attribute__((cold))
+#define weak_sym __attribute__((weak))
+#define restrict __restrict__
+#define likely(expr) __builtin_expect(!!(expr), 1)
+#define unlikely(expr) __builtin_expect(!!(expr), 0)
+#define prefetchr(addr) __builtin_prefetch((addr), 0)
+#define prefetchw(addr) __builtin_prefetch((addr), 1)
+
+#ifndef __has_feature
+#    define __has_feature(x) (0)
+#endif
+
+#ifdef __has_cpp_attribute
+#    if __has_cpp_attribute(noreturn)
+#        define noreturn_attr [[noreturn]]
+#    endif
+#    if __has_cpp_attribute(nodiscard)
+#        define nodiscard_attr [[nodiscard]]
+#    elif __has_cpp_attribute(gnu::warn_unused_result)
+#        define nodiscard_attr [[gnu::warn_unused_result]]
+#    endif
+#endif
+
+#ifndef noreturn_attr
+#    define noreturn_attr __attribute__((noreturn))
+#endif
+
+#ifndef nodiscard_attr
+#    define nodiscard_attr __attribute__((warn_unused_result))
+#endif
+
+#ifdef assert
+#    undef assert
+#endif
+
+#ifdef NDEBUG
+#    define DEBUG 0
+#    define assert(...) (static_cast<void>(0))
+#    define assume(expr, ...) (likely((expr)) ? static_cast<void>(0) : __builtin_unreachable())
+#else
+#    define DEBUG 1
+
+namespace gatbl {
+
+/** Handler for assertion/assumption fails
+ * Do not throw exception on purpose (directly terminate)
+ */
+noreturn_attr noinline_fun inline void
+              abort_message(const char* msg...)
+{
+    va_list args;
+    va_start(args, msg);
+    std::vfprintf(stderr, msg, args);
+    va_end(args);
+    std::fflush(stderr);
+    std::abort();
+}
+
+}
+
+#    define __gatbl_sourceloc_fail(what, msg, ...) gatbl::abort_message("%s:%u %s\n\t" #what " failed: " #msg "\n", __FILE__, __LINE__, static_cast<const char*>(__PRETTY_FUNCTION__), ##__VA_ARGS__))
+#    define assert(expr, ...) (likely((expr)) ? static_cast<void>(0) : __gatbl_sourceloc_fail("Assertion '" #expr "'", ##__VA_ARGS__)
+#    define assume(expr, ...) (likely((expr)) ? static_cast<void>(0) : __gatbl_sourceloc_fail("Assumption '" #expr "'", ##__VA_ARGS__)
+
+#endif
+
+#endif // GATBL_COMMON_HPP

--- a/makefile
+++ b/makefile
@@ -1,10 +1,16 @@
 CC=g++
-CFLAGS= -Wall -Ofast -std=c++11  -flto -pipe -funit-at-a-time -fopenmp -lz -Isparsepp -g
-LDFLAGS=-flto -lpthread -fopenmp -lz  -Isparsepp -g
-
-
+CFLAGS=-Wall -g -std=c++11 -pipe -funit-at-a-time -fopenmp -lz -Isparsepp -g
+LDFLAGS=-lpthread -fopenmp -lz  -Isparsepp -g
 
 EXEC=Miekki
+
+ASSERTS ?= $(DEBUG)
+ifeq ($(DEBUG), 1)
+        CFLAGS+=-DDEBUG -Og
+else
+        CFLAGS+=-DNDEBUG -Ofast -flto -march=native -mtune=native
+        LDFLAGS+=-flto
+endif
 
 
 all: $(EXEC)

--- a/matrix.hpp
+++ b/matrix.hpp
@@ -1,0 +1,205 @@
+#ifndef MATRIX_HPP
+#define MATRIX_HPP
+
+#include <memory>
+#include <algorithm>
+#include "common.hpp"
+
+namespace matrix {
+
+using idx_t = int; // Signed indices allows better loop optimizations
+
+struct slice {
+    idx_t offset;
+    idx_t size;
+};
+
+struct strided_slice {
+    idx_t offset;
+    idx_t size;
+    idx_t stride;
+};
+
+
+template<typename T> struct slicevec;
+
+/// Reference to a subarray
+template<typename T>
+struct refvec {
+    using idx_t = int;
+    using scalar_t = T;
+    using ref_t = scalar_t&;
+    using const_ref_t = scalar_t&; // Constness is contained in T if needed
+    using iterator = scalar_t*;
+    using const_iterator = scalar_t*;
+
+    refvec(scalar_t* data ,idx_t size) : _data(data), _size(size) {}
+    refvec(refvec&&) = default;
+    refvec(const refvec&) = default;
+
+    scalar_t* data() const { return _data; }
+    iterator begin() const { return _data; }
+    iterator end() const { return _data + _size; }
+
+    ref_t operator[](idx_t i) const {
+        assume(i >= 0, "negative indice");
+        assume(i < _size, "out of bound indice");
+        return _data[i];
+    }
+
+    refvec<T> operator[](slice s) {
+        assume(s.offset >= 0, "negative offset");
+        assume(s.offset + s.size <= _size, "Out of bound slice");
+        return refvec<T>(_data + s.offset, s.size);
+    }
+
+    slicevec<T> operator[](strided_slice s) {
+        assume(s.offset >= 0, "negative offset");
+        idx_t min = s.offset;
+        idx_t max = s.offset + (s.size-1)*s.stride;
+        assume(min >= 0 && min < _size && max >= 0 && max < _size, "Slice out of bound");
+        return slicevec<T>(_data, s);
+    }
+
+    idx_t size() const { return _size; }
+
+    scalar_t* _data;
+    idx_t _size;
+};
+
+
+/// Reference to a subarray with strides
+template<typename T>
+struct slicevec : protected refvec<T> {
+    using scalar_t = T;
+    using ref_t = scalar_t&;
+
+    using refvec<T>::size;
+
+    // Refereced memory size: this->_size * this->_stride
+
+    slicevec(scalar_t* data , strided_slice s) : refvec<T>(data + s.offset, s.size), _stride(s.stride) {}
+    slicevec(slicevec&&) = default;
+    slicevec(const slicevec&) = default;
+
+    idx_t stride() const { return _stride; }
+
+    ref_t operator[](idx_t i) const {
+        assume(i >= 0, "negative indice");
+        assume(i < this->_size, "out of bound indice");
+        return this->_data[i*_stride];
+    }
+
+    slicevec<T> operator[](slice s) {
+        assume(s.offset >= 0, "negative offset");
+        assume(s.offset + s.size <= this->_size, "Out of bound slice");
+        return slicevec<T>(this->_data, {s.offset * _stride, s.size, _stride});
+    }
+
+    slicevec<T> operator[](strided_slice s) {
+        assume(s.offset >= 0, "negative offset");
+        idx_t min = s.offset;
+        idx_t max = s.offset + (s.size-1)*s.stride;
+        assume(min >= 0 && min < this->_size && max >= 0 && max < this->_size, "Slice out of bound");
+        return slicevec<T>(this->_data, {s.offset * _stride, s.size, s.stride * _stride});
+    }
+
+
+    struct iterator {
+        scalar_t* ptr;
+        idx_t stride;
+
+        iterator& operator++() { ptr += stride; return *this; }
+        bool operator<(const iterator& other) { return ptr < other.ptr; }
+        bool operator!=(const iterator& other) { return ptr != other.ptr; }
+        ref_t operator*() const { return *ptr; }
+    };
+
+    using const_iterator = iterator;
+
+    iterator begin() const { return {this->data(), _stride}; }
+    iterator end() const { return {this->data() + this->size() * _stride, _stride}; }
+
+    idx_t _stride;
+};
+
+
+/// Own a memory range of T values
+template<typename T>
+struct vector {
+    using idx_t = int;
+    using scalar_t = T;
+    using ref_t = scalar_t&;
+    using const_ref_t = const scalar_t&;
+    using iterator = scalar_t*;
+    using const_iterator = const scalar_t*;
+    using unique_arr_t = std::unique_ptr<scalar_t[]>;
+    typedef scalar_t (&array_ref)[];
+    typedef const scalar_t (&const_array_ref)[];
+
+    vector(idx_t size) : _data(new scalar_t[size_t(size)]), _size(size) {}
+    vector(idx_t size, scalar_t v) : _data(new scalar_t[size_t(size)]{v}), _size(size) {}
+    vector(unique_arr_t&& data, idx_t size) : _data(std::move(data)), _size(size) {}
+    vector(const scalar_t (& data)[], idx_t size) : vector(size) {
+        std::copy(data, data + _size);
+    }
+    vector(vector&&) = default;
+    vector& operator=(vector&&) = default;
+    explicit vector(const vector& from) : vector(from._data.get(), from._size) {}
+
+    array_ref data() { return _data.get(); }
+    const_array_ref data() const { return _data.get(); }
+    idx_t size() const {return _size; }
+
+    unique_arr_t as_unique_ptr() && {
+        return std::move(_data);
+    }
+
+    operator refvec<T>() { return {_data.get(), _size}; }
+    operator refvec<const T>() const { return {_data.get(), _size}; }
+
+    template<typename I> auto operator[](I i) -> decltype(this->operator refvec<T>()[i])
+    { return this->operator refvec<T>()[i]; }
+    template<typename I> auto operator[](I i) const -> decltype(this->operator refvec<const T>()[i])
+    { return *this->operator refvec<const T>()[i]; }
+
+    iterator begin() { return _data.get(); }
+    iterator end() { return _data.get() + _size; }
+    const_iterator begin() const { return _data.get(); }
+    const_iterator end() const { return _data.get() + _size; }
+
+    unique_arr_t _data;
+    idx_t _size;
+};
+
+template<typename base>
+struct matrix_t : public base {
+    using typename base::idx_t;
+    using typename base::scalar_t;
+
+    matrix_t(idx_t r, idx_t c) : base(r*c), _rows(r), _cols(c) {}
+    matrix_t(idx_t r, idx_t c, scalar_t v) : base(r*c, v), _rows(r), _cols(c) {}
+//    template<typename T, typename=decltype(base(std::declval<T>()), idx_t{})>
+//    matrix(T&& x, idx_t r, idx_t c) : base(std::forward<T>(x), r * c), _rows(r), _cols(c) {}
+
+    idx_t cols() const { return _cols; }
+    idx_t rows() const { return this->size() / _cols; }
+
+    auto row(idx_t i) -> decltype((*this)[slice{}]) { return (*this)[slice{_cols * i, _cols}]; }
+    auto row(idx_t i) const -> decltype((*this)[slice{}]) { return (*this)[slice{_cols * i, _cols}]; }
+
+    auto col(idx_t i) -> decltype((*this)[strided_slice{}]) { return (*this)[strided_slice{i, _rows, _cols}]; }
+    auto col(idx_t i) const -> decltype((*this)[strided_slice{}]) { return (*this)[strided_slice{i, _rows, _cols}]; }
+
+    auto operator() (idx_t r, idx_t c) -> decltype((*this)[idx_t{}]) { return static_cast<refvec<scalar_t>>(*this)[r*_cols + c]; }
+    auto operator() (idx_t r, idx_t c) const -> decltype((*this)[idx_t{}]) { return this[r*_cols + c]; }
+
+    idx_t _rows, _cols;
+};
+
+template<typename T> using matrix = matrix_t<vector<T>>;
+template<typename T> using matrix_ref = matrix_t<refvec<T>>;
+
+} /* namespace matrix */
+
+#endif // MATRIX_HPP


### PR DESCRIPTION
* Add a matrix abstraction to represent sketches and results (not fully integrated yet)
* Implement a min-heap top k algorithm to filter results.
* fix a bug in `get_minimizers()`. Decoded sketches of odd genomes were filled with zero
* fix a bug in `query_sequences()`: the sketch for a single sequence is stored as a row. But the code was reading it by column.
* fix a bug in `insert_sequences` : the `approx_cardinality` accumulator was not reset (yet after fixing it, the result seems wrong)


TODO:
 * Genome sequence are not added in the fof order, because of concurrency. The output indices in results are random. Since names are not backed in the index, a query result cannot be interpreted.
 * Implement vectorized operation on matrices